### PR TITLE
Remove become first responder from message view

### DIFF
--- a/MessageViewController/MessageView.swift
+++ b/MessageViewController/MessageView.swift
@@ -52,10 +52,6 @@ public final class MessageView: UIView, MessageTextViewListener {
         button.imageEdgeInsets = .zero
 
         updateEmptyTextStates()
-
-        let tap = UITapGestureRecognizer(target: self, action: #selector(becomeFirstResponder))
-        tap.cancelsTouchesInView = false
-        addGestureRecognizer(tap)
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -200,10 +196,6 @@ public final class MessageView: UIView, MessageTextViewListener {
 
     public override func resignFirstResponder() -> Bool {
         return textView.resignFirstResponder()
-    }
-
-    public override func becomeFirstResponder() -> Bool {
-        return textView.becomeFirstResponder()
     }
 
     // MARK: Private API


### PR DESCRIPTION
Closes #4
- Removes tap gesture on message view
- Removed become first responder for taps