### PR TITLE
Highlighting with NSAttributedString's

### DIFF
--- a/Examples/Examples/ViewController.swift
+++ b/Examples/Examples/ViewController.swift
@@ -38,6 +38,7 @@ class ViewController: MessageViewController, UITableViewDataSource, UITableViewD
         messageAutocompleteController.tableView.dataSource = self
         messageAutocompleteController.tableView.delegate = self
         messageAutocompleteController.register(prefix: "@")
+        messageAutocompleteController.autocompleteTextAttributes = ["@": [NSAttributedStringKey.font: UIFont.preferredFont(forTextStyle: .body), NSAttributedStringKey.foregroundColor: UIColor(red: 0, green: 122/255, blue: 1, alpha: 1), NSAttributedStringKey.backgroundColor: UIColor(red: 0, green: 122/255, blue: 1, alpha: 0.1)]]
         messageAutocompleteController.delegate = self
 
         setup(scrollView: tableView)

--- a/Examples/Examples/ViewController.swift
+++ b/Examples/Examples/ViewController.swift
@@ -38,7 +38,11 @@ class ViewController: MessageViewController, UITableViewDataSource, UITableViewD
         messageAutocompleteController.tableView.dataSource = self
         messageAutocompleteController.tableView.delegate = self
         messageAutocompleteController.register(prefix: "@")
-        messageAutocompleteController.autocompleteTextAttributes = ["@": [NSAttributedStringKey.font: UIFont.preferredFont(forTextStyle: .body), NSAttributedStringKey.foregroundColor: UIColor(red: 0, green: 122/255, blue: 1, alpha: 1), NSAttributedStringKey.backgroundColor: UIColor(red: 0, green: 122/255, blue: 1, alpha: 0.1)]]
+        
+        // Set custom attributes for an autocompleted string
+        let tintColor = UIColor(red: 0, green: 122/255, blue: 1, alpha: 1)
+        messageAutocompleteController.autocompleteTextAttributes = ["@": [.font: UIFont.preferredFont(forTextStyle: .body), .foregroundColor: tintColor, .backgroundColor: tintColor.withAlphaComponent(0.1)]]
+        
         messageAutocompleteController.delegate = self
 
         setup(scrollView: tableView)

--- a/MessageViewController.xcodeproj/project.pbxproj
+++ b/MessageViewController.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		29CC29471FF42687006B6DE7 /* String+WordAtRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CC29451FF42687006B6DE7 /* String+WordAtRange.swift */; };
 		29CC29481FF42687006B6DE7 /* UIView+iOS11.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CC29461FF42687006B6DE7 /* UIView+iOS11.swift */; };
 		29CC29491FF81F1F006B6DE7 /* String+WordAtRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CC29451FF42687006B6DE7 /* String+WordAtRange.swift */; };
+		38199E112022792600ADFE76 /* NSAttributedString+ReplaceRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38199E102022792600ADFE76 /* NSAttributedString+ReplaceRange.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +55,7 @@
 		29CC29431FF4267F006B6DE7 /* String+WordAtRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+WordAtRangeTests.swift"; sourceTree = "<group>"; };
 		29CC29451FF42687006B6DE7 /* String+WordAtRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+WordAtRange.swift"; sourceTree = "<group>"; };
 		29CC29461FF42687006B6DE7 /* UIView+iOS11.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+iOS11.swift"; sourceTree = "<group>"; };
+		38199E102022792600ADFE76 /* NSAttributedString+ReplaceRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+ReplaceRange.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +110,7 @@
 				2904821D1FED90340053978C /* UIButton+BottomHeightOffset.swift */,
 				290482161FED90340053978C /* UIScrollView+StopScrolling.swift */,
 				2904821E1FED90340053978C /* UITextView+Prefixes.swift */,
+				38199E102022792600ADFE76 /* NSAttributedString+ReplaceRange.swift */,
 				29CC29461FF42687006B6DE7 /* UIView+iOS11.swift */,
 			);
 			path = MessageViewController;
@@ -242,6 +245,7 @@
 				290482201FED90340053978C /* MessageViewController.swift in Sources */,
 				29CC29481FF42687006B6DE7 /* UIView+iOS11.swift in Sources */,
 				29792B151FFAE7FC007A0C57 /* MessageAutocompleteController.swift in Sources */,
+				38199E112022792600ADFE76 /* NSAttributedString+ReplaceRange.swift in Sources */,
 				2904821F1FED90340053978C /* UIScrollView+StopScrolling.swift in Sources */,
 				29CC29471FF42687006B6DE7 /* String+WordAtRange.swift in Sources */,
 				290482271FED90340053978C /* UITextView+Prefixes.swift in Sources */,

--- a/MessageViewController.xcodeproj/project.pbxproj
+++ b/MessageViewController.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		29CC29481FF42687006B6DE7 /* UIView+iOS11.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CC29461FF42687006B6DE7 /* UIView+iOS11.swift */; };
 		29CC29491FF81F1F006B6DE7 /* String+WordAtRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CC29451FF42687006B6DE7 /* String+WordAtRange.swift */; };
 		38199E112022792600ADFE76 /* NSAttributedString+ReplaceRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38199E102022792600ADFE76 /* NSAttributedString+ReplaceRange.swift */; };
+		38D26FB12023D01900B2B7B5 /* NSAttributedString+HighlightingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D26FB02023D01900B2B7B5 /* NSAttributedString+HighlightingTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -56,6 +57,7 @@
 		29CC29451FF42687006B6DE7 /* String+WordAtRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+WordAtRange.swift"; sourceTree = "<group>"; };
 		29CC29461FF42687006B6DE7 /* UIView+iOS11.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+iOS11.swift"; sourceTree = "<group>"; };
 		38199E102022792600ADFE76 /* NSAttributedString+ReplaceRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+ReplaceRange.swift"; sourceTree = "<group>"; };
+		38D26FB02023D01900B2B7B5 /* NSAttributedString+HighlightingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+HighlightingTests.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -122,6 +124,7 @@
 				29CC293C1FF4266D006B6DE7 /* Info.plist */,
 				29CC293A1FF4266D006B6DE7 /* MessageViewControllerTests.swift */,
 				29CC29431FF4267F006B6DE7 /* String+WordAtRangeTests.swift */,
+				38D26FB02023D01900B2B7B5 /* NSAttributedString+HighlightingTests.swift */,
 			);
 			path = MessageViewControllerTests;
 			sourceTree = "<group>";
@@ -257,6 +260,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				29CC293B1FF4266D006B6DE7 /* MessageViewControllerTests.swift in Sources */,
+				38D26FB12023D01900B2B7B5 /* NSAttributedString+HighlightingTests.swift in Sources */,
 				29CC29441FF4267F006B6DE7 /* String+WordAtRangeTests.swift in Sources */,
 				29CC29491FF81F1F006B6DE7 /* String+WordAtRange.swift in Sources */,
 			);

--- a/MessageViewController/MessageAutocompleteController.swift
+++ b/MessageViewController/MessageAutocompleteController.swift
@@ -244,6 +244,7 @@ public final class MessageAutocompleteController: MessageTextViewListener {
                     
                     let emptyString = NSAttributedString(string: "", attributes: typingTextAttributes)
                     textView.attributedText = textView.attributedText.replacingCharacters(in: range, with: emptyString)
+                    textView.selectedRange = NSRange(location: range.location, length: 0)
                     self.preserveTypingAttributes(for: textView)
                 })
             }

--- a/MessageViewController/MessageTextView.swift
+++ b/MessageViewController/MessageTextView.swift
@@ -10,6 +10,7 @@ import UIKit
 public protocol MessageTextViewListener: class {
     func didChange(textView: MessageTextView)
     func didChangeSelection(textView: MessageTextView)
+    func willChangeRange(textView: MessageTextView, to range: NSRange)
 }
 
 open class MessageTextView: UITextView, UITextViewDelegate {
@@ -130,6 +131,11 @@ open class MessageTextView: UITextView, UITextViewDelegate {
 
     public func textViewDidChangeSelection(_ textView: UITextView) {
         enumerateListeners { $0.didChangeSelection(textView: self) }
+    }
+    
+    public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        enumerateListeners { $0.willChangeRange(textView: self, to: range) }
+        return true
     }
 
 }

--- a/MessageViewController/MessageView.swift
+++ b/MessageViewController/MessageView.swift
@@ -240,5 +240,7 @@ public final class MessageView: UIView, MessageTextViewListener {
     public func didChangeSelection(textView: MessageTextView) {
         delegate?.selectionDidChange(messageView: self)
     }
+    
+    public func willChangeRange(textView: MessageTextView, to range: NSRange) {}
 
 }

--- a/MessageViewController/NSAttributedString+ReplaceRange.swift
+++ b/MessageViewController/NSAttributedString+ReplaceRange.swift
@@ -1,0 +1,25 @@
+//
+//  NSAttributedString+ReplaceRange.swift
+//  MessageViewController
+//
+//  Created by Nathan Tannar on 1/31/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import Foundation
+
+extension NSAttributedString {
+    
+    func replacingCharacters(in range: NSRange, with attributedString: NSAttributedString) -> NSMutableAttributedString {
+        let ns = NSMutableAttributedString(attributedString: self)
+        ns.replaceCharacters(in: range, with: attributedString)
+        return ns
+    }
+    
+    static func +(lhs: NSAttributedString, rhs: NSAttributedString) -> NSAttributedString {
+        let ns = NSMutableAttributedString(attributedString: lhs)
+        ns.append(rhs)
+        return NSAttributedString(attributedString: ns)
+    }
+}
+

--- a/MessageViewControllerTests/NSAttributedString+HighlightingTests.swift
+++ b/MessageViewControllerTests/NSAttributedString+HighlightingTests.swift
@@ -1,0 +1,86 @@
+//
+//  NSAttributedString+HighlightingTests.swift
+//  MessageViewControllerTests
+//
+//  Created by Nathan Tannar on 2/1/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import XCTest
+import MessageViewController
+
+class NSAttributedString_HighlightingTests: XCTestCase {
+    
+    var controller: MessageAutocompleteController?
+    var textView: MessageTextView?
+    
+    /// A key used for referencing which substrings were autocompletes
+    private let NSAttributedAutocompleteKey = NSAttributedStringKey.init("com.system.autocompletekey")
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        
+        textView = MessageTextView()
+        controller = MessageAutocompleteController(textView: textView!)
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        controller = nil
+        textView = nil
+        
+        super.tearDown()
+    }
+    
+    func test_TailHighlight() {
+        
+        guard let textView = textView else { return XCTAssert(false, "textView nil") }
+        guard let controller = controller else { return XCTAssert(false, "controller nil") }
+        
+        let prefix = "@"
+        controller.register(prefix: prefix)
+        
+        let nonAttributedText = "Some text " + prefix
+        textView.attributedText = NSAttributedString(string: nonAttributedText)
+        controller.didChangeSelection(textView: textView)
+        guard controller.selection != nil else {
+            return XCTAssert(false, "Selection nil")
+        }
+        let autocompleteText = "username"
+        controller.accept(autocomplete: autocompleteText)
+        let range = NSRange(location: nonAttributedText.count - 1, length: autocompleteText.count)
+        let attributes = textView.attributedText.attributes(at: range.lowerBound, longestEffectiveRange: nil, in: range)
+        guard let isAutocompleted = attributes[NSAttributedAutocompleteKey] as? Bool else {
+            return XCTAssert(false, attributes.debugDescription)
+        }
+        XCTAssert(isAutocompleted, attributes.debugDescription)
+    }
+    
+    func test_HeadHighlight() {
+        
+        guard let textView = textView else { return XCTAssert(false, "textView nil") }
+        guard let controller = controller else { return XCTAssert(false, "controller nil") }
+        
+        let prefix = "@"
+        controller.register(prefix: prefix)
+        
+        let nonAttributedText = prefix
+        textView.attributedText = NSAttributedString(string: nonAttributedText)
+        controller.didChangeSelection(textView: textView)
+        guard controller.selection != nil else {
+            return XCTAssert(false, "Selection nil")
+        }
+        let autocompleteText = "username"
+        controller.accept(autocomplete: autocompleteText)
+        
+        let highlightRange = NSRange(location: nonAttributedText.count - 1, length: autocompleteText.count)
+        let attributes = textView.attributedText.attributes(at: highlightRange.lowerBound, longestEffectiveRange: nil, in: highlightRange)
+        guard let isAutocompleted = attributes[NSAttributedAutocompleteKey] as? Bool else {
+            return XCTAssert(false, attributes.debugDescription)
+        }
+        XCTAssert(isAutocompleted, attributes.debugDescription)
+    }
+    
+}
+

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ messageView.font = .systemFont(ofSize: 17)
 messageView.set(buttonTitle: "Send", for: .normal)
 messageView.addButton(target: self, action: #selector(onButton))
 messageView.buttonTint = .blue
+
+// Set custom attributes for an autocompleted string
+let tintColor = .blue
+messageAutocompleteController.autocompleteTextAttributes = ["@": [.font: UIFont.preferredFont(forTextStyle: .body), .foregroundColor: tintColor, .backgroundColor: tintColor.withAlphaComponent(0.1)]]
 ```
 
 ## Autocomplete


### PR DESCRIPTION
This is for #8 and adds the ability to have text highlighting for autocomplete. This is done by switching the text replacement to NSAttributedString's with custom attributes. 

Management of autocompleted substrings was done by applying a custom NSAttributedStringKey.

Open to all feedback 😊 

### Breaking Change

- Added a new delegate method to `MessageTextViewListener`, `func willChangeRange(textView: MessageTextView, to range: NSRange)` which allowed for the observation of text range changes such that the entire autocomplete string is deleted rather than character by character