### PR TITLE
Remove autocomplete on single backspace

### DIFF
--- a/MessageViewController/MessageAutocompleteController.swift
+++ b/MessageViewController/MessageAutocompleteController.swift
@@ -237,25 +237,24 @@ public final class MessageAutocompleteController: MessageTextViewListener {
     
     public func willChangeRange(textView: MessageTextView, to range: NSRange) {
         
-        // range.length > 0: Backspace/removing text
+        // range.length == 1: Remove single character
         // range.lowerBound < textView.selectedRange.lowerBound: Ignore trying to delete
         //      the substring if the user is already doing so
-        if range.length > 0, range.lowerBound < textView.selectedRange.lowerBound {
+        if range.length == 1, range.lowerBound < textView.selectedRange.lowerBound {
             
             // Backspace/removing text
             let attribute = textView.attributedText
                 .attributes(at: range.lowerBound, longestEffectiveRange: nil, in: range)
                 .filter { return $0.key == NSAttributedAutocompleteKey }
-            
-            if (attribute[NSAttributedAutocompleteKey] as? Bool ?? false) == true {
-                
+
+            if let isAutocomplete = attribute[NSAttributedAutocompleteKey] as? Bool, isAutocomplete {
                 // Remove the autocompleted substring
                 let lowerRange = NSRange(location: 0, length: range.location + 1)
                 textView.attributedText.enumerateAttribute(NSAttributedAutocompleteKey, in: lowerRange, options: .reverse, using: { (_, range, stop) in
-                    
+
                     // Only delete the first found range
                     defer { stop.pointee = true }
-                    
+
                     let emptyString = NSAttributedString(string: "", attributes: typingTextAttributes)
                     textView.attributedText = textView.attributedText.replacingCharacters(in: range, with: emptyString)
                     textView.selectedRange = NSRange(location: range.location, length: 0)


### PR DESCRIPTION
Improves https://github.com/rnystrom/GitHawk/issues/1514

I did a little reverse engineering of Slack to figure out how they were dealing with this. The text after a mention is still highlighted for autocorrect, so they do not toggle it on and off, they simply ignore the replacement.

**This only automatically removes an autocorrect for a single backspace starting at the end.**

 This is a bit of a heuristic. It works well because a suggested autocorrect is rarely if ever 1 character long.

#### Existing problems that this does not fix:
- Deleting any portion of an `autocomplete` from the middle
(Slack handles this by changing the text but removing the autocomplete attributes)




