### PR TITLE
Use text container insets to avoid clipping selection bubbles

### DIFF
--- a/MessageViewController/MessageTextView.swift
+++ b/MessageViewController/MessageTextView.swift
@@ -87,8 +87,8 @@ open class MessageTextView: UITextView, UITextViewDelegate {
 
         let placeholderSize = placeholderLabel.bounds.size
         placeholderLabel.frame = CGRect(
-            x: bounds.minX,
-            y: bounds.minY,
+            x: textContainerInset.left,
+            y: textContainerInset.top,
             width: placeholderSize.width,
             height: placeholderSize.height
         )

--- a/MessageViewController/MessageView.swift
+++ b/MessageViewController/MessageView.swift
@@ -81,11 +81,13 @@ public final class MessageView: UIView, MessageTextViewListener {
         }
     }
 
-    public var inset: UIEdgeInsets = .zero {
-        didSet {
+    public var inset: UIEdgeInsets {
+        set {
+            textView.textContainerInset = newValue
             setNeedsLayout()
             delegate?.wantsLayout(messageView: self)
         }
+        get { return textView.textContainerInset }
     }
 
     public var buttonLeftInset: CGFloat = 0 {
@@ -159,22 +161,19 @@ public final class MessageView: UIView, MessageTextViewListener {
             width: bounds.width - util_safeAreaInsets.left - util_safeAreaInsets.right,
             height: bounds.height
         )
-        let insetBounds = UIEdgeInsetsInsetRect(safeBounds, inset)
-
         let buttonSize = button.bounds.size
-
         let textViewFrame = CGRect(
-            x: insetBounds.minX,
-            y: insetBounds.minY,
-            width: insetBounds.width - buttonSize.width - buttonLeftInset,
+            x: safeBounds.minX,
+            y: safeBounds.minY,
+            width: safeBounds.width - buttonSize.width - buttonLeftInset,
             height: textViewHeight
         )
         textView.frame = textViewFrame
 
         // adjust by bottom offset so content is flush w/ text view
         button.frame = CGRect(
-            x: textViewFrame.maxX + buttonLeftInset,
-            y: textViewFrame.maxY - buttonSize.height + button.bottomHeightOffset,
+            x: textViewFrame.maxX + buttonLeftInset - inset.right,
+            y: textViewFrame.maxY - buttonSize.height + button.bottomHeightOffset - inset.bottom,
             width: buttonSize.width,
             height: buttonSize.height
         )
@@ -201,14 +200,17 @@ public final class MessageView: UIView, MessageTextViewListener {
     // MARK: Private API
 
     internal var height: CGFloat {
-        return inset.top
-            + inset.bottom
-            + textViewHeight
-            + (contentView?.bounds.height ?? 0)
+        return textViewHeight + (contentView?.bounds.height ?? 0)
     }
 
     internal var textViewHeight: CGFloat {
-        return min(maxHeight, max(textView.font?.lineHeight ?? 0, textView.contentSize.height))
+        return ceil(min(
+            maxHeight,
+            max(
+                textView.font?.lineHeight ?? 0,
+                textView.contentSize.height
+            )
+        ))
     }
 
     internal var maxHeight: CGFloat {


### PR DESCRIPTION
![simulator screen shot - iphone 8 plus - 2018-02-25 at 19 54 48](https://user-images.githubusercontent.com/739696/36648793-dcbf4136-1a65-11e8-991f-9cc033d0572e.png)
