### PR TITLE
Dynamically increase textview size according to maxScreenRatio

### DIFF
--- a/MessageViewController/MessageView.swift
+++ b/MessageViewController/MessageView.swift
@@ -28,6 +28,9 @@ public final class MessageView: UIView, MessageTextViewListener {
         case right
     }
 
+    internal var buttonAction: Selector?
+    internal var keyboardHeight: CGFloat = 0
+
     internal override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -164,6 +167,13 @@ public final class MessageView: UIView, MessageTextViewListener {
         }
     }
 
+    public var maxScreenRatio: CGFloat = 0 {
+        didSet {
+            maxScreenRatio = 0...1 ~= maxScreenRatio ? maxScreenRatio : 0
+            delegate?.wantsLayout(messageView: self)
+        }
+    }
+    
     public func add(contentView: UIView) {
         self.contentView?.removeFromSuperview()
         assert(contentView.bounds.height > 0, "Must have a non-zero content height")
@@ -295,19 +305,21 @@ public final class MessageView: UIView, MessageTextViewListener {
     internal var height: CGFloat {
         return textViewHeight + (contentView?.bounds.height ?? 0)
     }
-
-    internal var textViewHeight: CGFloat {
-        return ceil(min(
-            maxHeight,
-            max(
-                textView.font?.lineHeight ?? 0,
-                textView.contentSize.height
-            )
-        ))
-    }
-
-    internal var maxHeight: CGFloat {
+    
+    internal var maxLineHeight: CGFloat {
         return (font?.lineHeight ?? 0) * CGFloat(maxLineCount)
+    }
+    
+    internal var maxScreenHeight: CGFloat {
+        return maxScreenRatio * (superview?.frame.height ?? 0) - keyboardHeight
+    }
+    
+    internal var maxHeight: CGFloat {
+        return max(maxScreenRatio, maxLineHeight)
+    }
+    
+    internal var textViewHeight: CGFloat {
+        return ceil(min(maxHeight, max(textView.font?.lineHeight ?? 0, textView.contentSize.height)))
     }
 
     internal func updateEmptyTextStates() {

--- a/MessageViewController/MessageView.swift
+++ b/MessageViewController/MessageView.swift
@@ -28,9 +28,6 @@ public final class MessageView: UIView, MessageTextViewListener {
         case right
     }
 
-    internal var buttonAction: Selector?
-    internal var keyboardHeight: CGFloat = 0
-
     internal var heightOffset: CGFloat = 0
     
     internal override init(frame: CGRect) {

--- a/MessageViewController/MessageView.swift
+++ b/MessageViewController/MessageView.swift
@@ -31,6 +31,8 @@ public final class MessageView: UIView, MessageTextViewListener {
     internal var buttonAction: Selector?
     internal var keyboardHeight: CGFloat = 0
 
+    internal var heightOffset: CGFloat = 0
+    
     internal override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -311,11 +313,11 @@ public final class MessageView: UIView, MessageTextViewListener {
     }
     
     internal var maxScreenHeight: CGFloat {
-        return maxScreenRatio * (superview?.frame.height ?? 0) - keyboardHeight
+        return maxScreenRatio * (superview?.frame.height ?? 0) - heightOffset
     }
     
     internal var maxHeight: CGFloat {
-        return max(maxScreenRatio, maxLineHeight)
+        return max(maxScreenHeight, maxLineHeight)
     }
     
     internal var textViewHeight: CGFloat {

--- a/MessageViewController/MessageViewController.swift
+++ b/MessageViewController/MessageViewController.swift
@@ -166,7 +166,8 @@ open class MessageViewController: UIViewController, MessageAutocompleteControlle
 
         let previousKeyboardHeight = keyboardHeight
         keyboardHeight = keyboardFrame.height
-
+        messageView.keyboardHeight = keyboardHeight
+        
         UIView.animate(withDuration: animationDuration) {
             guard let scrollView = self.scrollView else { return }
             // capture before changing the frame which might have weird side effects

--- a/MessageViewController/MessageViewController.swift
+++ b/MessageViewController/MessageViewController.swift
@@ -166,7 +166,7 @@ open class MessageViewController: UIViewController, MessageAutocompleteControlle
 
         let previousKeyboardHeight = keyboardHeight
         keyboardHeight = keyboardFrame.height
-        messageView.keyboardHeight = keyboardHeight
+        messageView.heightOffset = keyboardHeight + (scrollView?.util_safeAreaInsets.top ?? 0)
         
         UIView.animate(withDuration: animationDuration) {
             guard let scrollView = self.scrollView else { return }


### PR DESCRIPTION
PR is based on the suggestions in https://github.com/rnystrom/GitHawk/issues/1613

### Additions
- ability to set max ratio of screen to use for message view
- ability to set maxHeight of message view
- works well for devices with a hardware keyboard attached

### Tested On
- Devices: iPhone 7,8
- Simulators: iPhone 5s, X