### PR TITLE
Add a11y labels to the send button

### DIFF
--- a/MessageViewController/MessageView.swift
+++ b/MessageViewController/MessageView.swift
@@ -117,7 +117,9 @@ public final class MessageView: UIView, MessageTextViewListener {
         get { return textView.textContainerInset }
     }
 
-    public func setButton(icon: UIImage?, for state: UIControlState, position: ButtonPosition) {
+    /// - Parameter accessibilityLabel: A custom `accessibilityLabel` to set on the button.
+    /// If none is supplied, it will default to the icon's `accessibilityLabel`.
+    public func setButton(icon: UIImage?, for state: UIControlState, position: ButtonPosition, accessibilityLabel: String? = nil) {
         let button: UIButton
         switch position {
         case .left:
@@ -126,10 +128,13 @@ public final class MessageView: UIView, MessageTextViewListener {
             button = rightButton
         }
         button.setImage(icon, for: state)
+        button.accessibilityLabel = accessibilityLabel ?? icon?.accessibilityIdentifier
         buttonLayoutDidChange(button: button)
     }
 
-    public func setButton(title: String, for state: UIControlState, position: ButtonPosition) {
+    /// - Parameter accessibilityLabel: A custom `accessibilityLabel` to set on the button.
+    /// If none is supplied, it will default to the the supplied `title`.
+    public func setButton(title: String, for state: UIControlState, position: ButtonPosition, accessibilityLabel: String? = nil) {
         let button: UIButton
         switch position {
         case .left:
@@ -138,6 +143,7 @@ public final class MessageView: UIView, MessageTextViewListener {
             button = rightButton
         }
         button.setTitle(title, for: state)
+        button.accessibilityLabel = accessibilityLabel ?? title
         buttonLayoutDidChange(button: button)
     }
 


### PR DESCRIPTION
Fixes #56 

[For reference](https://github.com/GitHawkApp/MessageViewController/issues/56#issuecomment-380502155):

> Yeah, the only tricky thing is that at that point they would always be tied to the information passed into the function — if someone would want a different `accessibilityLabel` than the `title`, they would not be able to do so.
>
> So we could add an optional parameter that would override the accessibilityLabel, just not sure if that's scalable enough / overkill.