### PR TITLE
Calculate scroll view frame correctly

### DIFF
--- a/MessageViewController/MessageViewController.swift
+++ b/MessageViewController/MessageViewController.swift
@@ -127,10 +127,10 @@ open class MessageViewController: UIViewController, MessageAutocompleteControlle
         messageView.layoutIfNeeded()
 
         scrollView.frame = CGRect(
-            x: bounds.minX,
-            y: bounds.minY,
-            width: bounds.width,
-            height: messageViewFrame.minY
+            x: scrollView.frame.minX,
+            y: scrollView.frame.minY,
+            width: scrollView.frame.width,
+            height: messageViewFrame.minY - scrollView.frame.minY
         )
 
         messageAutocompleteController.layout(in: view, bottomY: messageViewFrame.minY)

--- a/MessageViewController/MessageViewController.swift
+++ b/MessageViewController/MessageViewController.swift
@@ -126,11 +126,12 @@ open class MessageViewController: UIViewController, MessageAutocompleteControlle
         // required for the nested UITextView to layout its internals correctly
         messageView.layoutIfNeeded()
 
+        let frame = scrollView.frame
         scrollView.frame = CGRect(
-            x: scrollView.frame.minX,
-            y: scrollView.frame.minY,
-            width: scrollView.frame.width,
-            height: messageViewFrame.minY - scrollView.frame.minY
+            x: frame.minX,
+            y: frame.minY,
+            width: frame.width,
+            height: messageViewFrame.minY - frame.minY
         )
 
         messageAutocompleteController.layout(in: view, bottomY: messageViewFrame.minY)


### PR DESCRIPTION
Hi @rnystrom 

Thank you for putting this repo together, it has been very useful.

I encountered an issue when adding a UITableView as a separate view to an existing UIViewController when the table view was positioned somewhere other than the top of the view. 

In the `layout` method, I noticed the `scrollView` was getting its frame from the view bounds, but this will obviously break the layout of the scroll view if it has its own frame within the view.

```swift
scrollView.frame = CGRect(
    x: bounds.minX,
    y: bounds.minY,
    width: bounds.width,
    height: messageViewFrame.minY
)
```

So I changed a few lines in `MessageViewController` so the scroll view would get its x, y, and width values from its existing frame, and then calculate its height relative to the `messageViewFrame`

```swift
scrollView.frame = CGRect(
    x: scrollView.frame.minX,
    y: scrollView.frame.minY,
    width: scrollView.frame.width,
    height: messageViewFrame.minY - scrollView.frame.minY
)
```

This way the scroll view gets positioned correctly within its containing view, and there are no other changes to way the message view controller gets setup.

```swift
override func viewDidLoad() {
        super.viewDidLoad()

        setup(scrollView: myTableView)

        borderColor = UIColor(red: 0.88, green: 0.88, blue: 0.88, alpha: 0.88)
        messageView.inset = UIEdgeInsets(top: 16, left: 8, bottom: 16, right: 8)
        messageView.layer.borderColor = UIColor.clear.cgColor
        messageView.textView.placeholderText = "Send message"
        messageView.textView.placeholderTextColor = .lightGray
       
        ...
    }
```

Let me know if that looks good or if there is anything you'd like changed.