### PR TITLE
Scroll view behavior fix

### DIFF
--- a/MessageViewController/MessageViewController+MessageViewDelegate.swift
+++ b/MessageViewController/MessageViewController+MessageViewDelegate.swift
@@ -17,7 +17,6 @@ extension MessageViewController: MessageViewDelegate {
     }
 
     internal func wantsLayout(messageView: MessageView) {
-        view.setNeedsLayout()
     }
 
     internal func selectionDidChange(messageView: MessageView) {}

--- a/MessageViewController/MessageViewController.swift
+++ b/MessageViewController/MessageViewController.swift
@@ -233,7 +233,6 @@ open class MessageViewController: UIViewController, MessageAutocompleteControlle
     // MARK: MessageAutocompleteControllerLayoutDelegate
 
     public func needsLayout(controller: MessageAutocompleteController) {
-        view.setNeedsLayout()
     }
 
 }


### PR DESCRIPTION
## Current behavior
The scroll view will jump to the middle when a keystroke is received by the keyboard no matter where the scroll view currently is.

## Fix
Remove calls to `setNeedsLayout` to avoid the scroll view from jumping