### PR TITLE
Revert "Calculate scroll view frame correctly"

### DIFF
--- a/MessageViewController/MessageViewController.swift
+++ b/MessageViewController/MessageViewController.swift
@@ -126,12 +126,11 @@ open class MessageViewController: UIViewController, MessageAutocompleteControlle
         // required for the nested UITextView to layout its internals correctly
         messageView.layoutIfNeeded()
 
-        let frame = scrollView.frame
         scrollView.frame = CGRect(
-            x: frame.minX,
-            y: frame.minY,
-            width: frame.width,
-            height: messageViewFrame.minY - frame.minY
+            x: bounds.minX,
+            y: bounds.minY,
+            width: bounds.width,
+            height: messageViewFrame.minY
         )
 
         messageAutocompleteController.layout(in: view, bottomY: messageViewFrame.minY)


### PR DESCRIPTION
Reverts GitHawkApp/MessageViewController#72

@jasonaibrahim fyi had to revert this b/c using `frame.width` results in the scroll view having a 0 width unless set elsewhere.