### PR TITLE
Removing the Font descender as button get push down

### DIFF
--- a/MessageViewController/MessageView.swift
+++ b/MessageViewController/MessageView.swift
@@ -283,15 +283,13 @@ public final class MessageView: UIView, MessageTextViewListener {
         let textViewMaxY = textViewY + textViewHeight
 
         // adjust for font descender so button aligns with the text baseline
-        let descender, pointSize: CGFloat
+        let pointSize: CGFloat
         if let font = textView.font {
-            descender = floor(font.descender)
             pointSize = ceil(font.pointSize)
         } else {
-            descender = 0
             pointSize = 0
         }
-        let buttonYStarter = textViewMaxY - textViewInset.bottom - (pointSize - descender)/2
+        let buttonYStarter = textViewMaxY - textViewInset.bottom - pointSize
 
         // adjust by bottom offset so content is flush w/ text view
         let leftButtonFrame = CGRect(


### PR DESCRIPTION
<img width="412" alt="51784462-03c77300-216f-11e9-840d-01544822d0d8" src="https://user-images.githubusercontent.com/17508663/51788651-8cadd100-21a6-11e9-8451-660fc57aa5b9.png">

Button get push down as we can see in the image, the button is not centre align with with the textview's  last line
Removing the font descender in buttonYStarter fix the issue. 