### PR TITLE
Update project for Swift 5 and Xcode 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: swift
-osx_image: xcode10.1
+osx_image: xcode11
 script:
   - xcodebuild clean test -project MessageViewController.xcodeproj -scheme MessageViewController -destination "platform=iOS Simulator,name=iPhone X,OS=11.3" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO -quiet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Added
 
+- **Breaking Change:** Requires Xcode 10.2+
+
+- Upgraded to Swift 5 and added Swift 5 support to the podspec. [#91](https://github.com/GitHawkApp/MessageViewController/pull/91) by [@benasher44](https://github.com/benasher44)
+
+# 0.2.0
+
+## Added
+
 - **Breaking Change:** Migrated to Swift 4.2
 
 - **Breaking Change:** Added a new delegate method to `MessageTextViewListener`, `func willChangeRange(textView: MessageTextView, to range: NSRange)` which allowed for the observation of text range changes such that the entire autocomplete string is deleted rather than character by character. [#15](https://github.com/GitHawkApp/MessageViewController/pull/15) by [@nathantannar4](https://github.com/nathantannar4)

--- a/MessageViewController.podspec
+++ b/MessageViewController.podspec
@@ -8,5 +8,9 @@ Pod::Spec.new do |spec|
   spec.source       = { :git => 'https://github.com/GitHawkApp/MessageViewController.git', :tag => spec.version.to_s }
   spec.source_files = 'MessageViewController/*.swift'
   spec.platform     = :ios, '9.0'
-  spec.swift_version = '4.2'
+  if spec.respond_to?(:swift_versions) then
+    spec.swift_versions = ['4.2', '5.0']
+  else
+    spec.swift_version = '4.2'
+  end
 end

--- a/MessageViewController.xcodeproj/project.pbxproj
+++ b/MessageViewController.xcodeproj/project.pbxproj
@@ -339,6 +339,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -393,6 +394,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -417,7 +419,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -439,7 +440,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.whoisryannystrom.MessageViewController;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -453,7 +453,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.whoisryannystrom.MessageViewControllerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -467,7 +466,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.whoisryannystrom.MessageViewControllerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/MessageViewController/UITextView+Prefixes.swift
+++ b/MessageViewController/UITextView+Prefixes.swift
@@ -28,8 +28,8 @@ internal extension UITextView {
             let result = text.word(at: caretRange)
             else { return nil }
 
-        let location = result.range.lowerBound.encodedOffset
-        let range = NSRange(location: location, length: result.range.upperBound.encodedOffset - location)
+        let location = result.range.lowerBound.utf16Offset(in: text)
+        let range = NSRange(location: location, length: result.range.upperBound.utf16Offset(in: text) - location)
 
         return (result.word, range)
     }


### PR DESCRIPTION
- Moved `SWIFT_VERSION` from target level to project level and bumped it to `5.0`
- Updated podspec to support Swift 5
- Updated travis to build with Xcode 11
- Fixed a Swift 5 deprecation warning about `String.Index.encodedOffset`